### PR TITLE
Fix CSV field size limit

### DIFF
--- a/lcplants.py
+++ b/lcplants.py
@@ -1,8 +1,11 @@
 import csv
+import io
 import json
 import pprint as pp
+import sys
 from collections import defaultdict
 
+csv.field_size_limit(500 * 1024 * 1024)
 
 taxonlist = ['Kingdom', 'Subkingdom', 'Superdivision', 'Division', 'Subdivision', 'Class', 'Subclass', 'Order', 'Family', 'Genus', 'Species', 'Subspecies', 'Variety', 'Subvariety', 'Cultivar', 'Forma']
 
@@ -32,24 +35,18 @@ def dicts(t): return {k: dicts(t[k]) for k in t}
 #pp.pprint(dicts(taxons()))
 
 
-
-
-def readcsv(): #runs, but utf-16 characters come through this one as /u00 code
-      with open('USDAsearch.txt', encoding = 'utf-8', errors = 'ignore') as csvfile:
-          reader = csv.DictReader(csvfile, delimiter=',', quotechar='"')
-          return [x for x in reader]
       
-def ioreadcsv(): #trips "Error: field larger than field limit (131072)"
-      with io.open('USDAsearch.txt', 'r', encoding = 'utf-16-le') as csvfile:
-          reader = csv.DictReader(csvfile, delimiter=',', quotechar='"')
-          return [x for x in reader]
+def readcsv():
+    with io.open('USDAsearch.txt', 'r', encoding = 'utf-16-le') as csvfile:
+        reader = csv.DictReader(csvfile, delimiter=',', quotechar='"')
+        return [x for x in reader]
 
 def writejson():
-    with open('plantsdict.json', 'w') as outfile:
+    with io.open('plantsdict.json', 'w') as outfile:
         json.dump(plants, outfile, sort_keys=True, indent=4)
 
 def readjson():
-    with open ('plantsdict.json', 'r', encoding='utf8') as jsonfile:
+    with io.open('plantsdict.json', 'r') as jsonfile:
         return (json.load(jsonfile))
 
 def cleandict(): #isn't working correctly, it's ripping species out of the scientific names and possibly other mistakes


### PR DESCRIPTION
I'm not sure if you want to accept this PR or not, but I think I solved the CSV limit issue, referencing the following documents on the Internet:
- https://docs.python.org/3/library/io.html
- https://stackoverflow.com/questions/31869247/understanding-the-buffering-argument-of-the-io-open-method-in-python-2-7
- https://lethain.com/handling-very-large-csv-and-xml-files-in-python/
- https://stackoverflow.com/questions/15063936/csv-error-field-larger-than-field-limit-131072
- https://stackoverflow.com/questions/2104080/how-to-check-file-size-in-python

Note that the new `plantsdict.json` file is considerably larger @ 1,326,728 lines of JSON vs. the previously-existing 47,990 lines of JSON. I have no idea why that is, unless your current `plantsdict.json` was built with something other than the current `USDAsearch.txt` file.

That said, what do you intend to do with this data (i.e., how do you intend to display it)? The kumu tree, right? It might work out that it knows how to decode the `\uXXXX` values, so no need to save the file as UTF-16 LE. I tried saving as UTF-16 LE, but the file was way too big. In order for it to support so many more characters, it just takes way more disc space to do so.

Bottom line? I think saving the JSON file with the `\uXXXX` values is the way to go, especially considering file size.